### PR TITLE
[FEAT] Add new "Send Contact" method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /examples/credentials.php
 /examples/media/*
 /src/Services/Temp/*
+/.idea

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ $phpevo->sendDocument($documentPath);
  * @return array
  */
 $phpevo->sendVideo($videoPath);
+
+/**
+ * @return array
+ */
+$phpevo->sendContact(new ContactMessage($phone, $nonStylizedPhone), $options);
 ```
 
 ## Roadmap

--- a/src/Services/Enums/PresenceTypeEnum.php
+++ b/src/Services/Enums/PresenceTypeEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PHPEvo\Services\Enums;
+
+enum PresenceTypeEnum: string
+{
+    case COMPOSING = 'composing';
+
+    public static function toArray(): array
+    {
+        return [
+            self::COMPOSING->value,
+        ];
+    }
+
+    public static function isValid(string $value): bool
+    {
+        return in_array($value, self::toArray(), true);
+    }
+}

--- a/src/Services/Models/ContactMessage.php
+++ b/src/Services/Models/ContactMessage.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PHPEvo\Services\Models;
+
+/**
+ * Class ContactMessage
+ */
+class ContactMessage
+{
+    /**
+     * ContactMessage constructor.
+     *
+     * @param  string  $phoneNumber  Phone number stylized (+55 31 9 9999-9999)
+     * @param  string  $wuid  Phone number non-stylized with country code (553198296801)
+     * @param  string|null  $email  Contact email address
+     * @param  string|null  $fullName  Contact full name
+     * @param  string|null  $organization  Organization name for the contact
+     * @param  string|null  $url  Page URL
+     */
+    public function __construct(
+        public string $phoneNumber,
+        public string $wuid,
+        public ?string $email = null,
+        public ?string $fullName = null,
+        public ?string $organization = null,
+        public ?string $url = null,
+    ) {
+    }
+}

--- a/src/Services/Models/ContactMessage.php
+++ b/src/Services/Models/ContactMessage.php
@@ -4,6 +4,8 @@ namespace PHPEvo\Services\Models;
 
 /**
  * Class ContactMessage
+ *
+ * @package Evolution\Services\Models
  */
 class ContactMessage
 {

--- a/src/Services/SendService.php
+++ b/src/Services/SendService.php
@@ -4,6 +4,7 @@ namespace PHPEvo\Services;
 
 use GuzzleHttp\Client;
 use PHPEvo\Services\Enums\MediaTypeEnum;
+use PHPEvo\Services\Models\ContactMessage;
 use PHPEvo\Services\Traits\HasHttpRequests;
 use RuntimeException;
 use stdClass;
@@ -287,6 +288,38 @@ class SendService
             'mimetype'  => $file->mimeType,
             'fileName'  => $file->fileName,
         ]);
+    }
+
+    /**
+     * send contact message
+     *
+     * @param ContactMessage $contact
+     * @param array|null $options
+     *  - delay (int): Tempo de espera antes do envio (ms).
+     *  - presence (PresenceTypeEnum): Tipo de presença a ser exibido (Opções disponíveis: composing).
+     * @return array
+     */
+    public function sendContact(ContactMessage $contact, ?array $options = null): array
+    {
+        //Se tiver presence valida se é um valor válido
+
+
+        $data = [
+            'number'         => $this->to,
+            'options'        => $options,
+            'contactMessage' => [
+                [
+                    'fullName'     => $contact->fullName,
+                    'wuid'         => $contact->wuid,
+                    'phoneNumber'  => $contact->phoneNumber,
+                    'organization' => $contact->organization,
+                    'email'        => $contact->email,
+                    'url'          => $contact->url,
+                ],
+            ],
+        ];
+
+        return $this->post('message/sendContact/' . $this->instance, $data);
     }
 
     /**

--- a/src/Services/SendService.php
+++ b/src/Services/SendService.php
@@ -3,7 +3,7 @@
 namespace PHPEvo\Services;
 
 use GuzzleHttp\Client;
-use PHPEvo\Services\Enums\MediaTypeEnum;
+use PHPEvo\Services\Enums\{MediaTypeEnum, PresenceTypeEnum};
 use PHPEvo\Services\Models\ContactMessage;
 use PHPEvo\Services\Traits\HasHttpRequests;
 use RuntimeException;
@@ -296,13 +296,14 @@ class SendService
      * @param ContactMessage $contact
      * @param array|null $options
      *  - delay (int): Tempo de espera antes do envio (ms).
-     *  - presence (PresenceTypeEnum): Tipo de presença a ser exibido (Opções disponíveis: composing).
+     *  - presence (PresenceTypeEnum): Tipo de presença a ser exibido
      * @return array
      */
     public function sendContact(ContactMessage $contact, ?array $options = null): array
     {
-        //Se tiver presence valida se é um valor válido
-
+        if (isset($options['presence']) && !PresenceTypeEnum::isValid($options['presence'])) {
+            throw new RuntimeException('Tipo de presença inválido.');
+        }
 
         $data = [
             'number'         => $this->to,

--- a/src/Services/SendService.php
+++ b/src/Services/SendService.php
@@ -6,7 +6,6 @@ use GuzzleHttp\Client;
 use PHPEvo\Services\Enums\{MediaTypeEnum, PresenceTypeEnum};
 use PHPEvo\Services\Models\ContactMessage;
 use PHPEvo\Services\Traits\HasHttpRequests;
-use RuntimeException;
 use stdClass;
 
 /**
@@ -302,22 +301,23 @@ class SendService
     public function sendContact(ContactMessage $contact, ?array $options = null): array
     {
         if (isset($options['presence']) && !PresenceTypeEnum::isValid($options['presence'])) {
-            throw new RuntimeException('Tipo de presença inválido.');
+            throw new \RuntimeException('Tipo de presença inválido.');
         }
+
+        // When field is empty, it will be removed from the array
+        $contactMessage = array_filter([
+            'fullName'     => $contact->fullName,
+            'wuid'         => $contact->wuid,
+            'phoneNumber'  => $contact->phoneNumber,
+            'organization' => $contact->organization,
+            'email'        => $contact->email,
+            'url'          => $contact->url,
+        ], fn ($value) => !empty($value));
 
         $data = [
             'number'         => $this->to,
             'options'        => $options,
-            'contactMessage' => [
-                [
-                    'fullName'     => $contact->fullName,
-                    'wuid'         => $contact->wuid,
-                    'phoneNumber'  => $contact->phoneNumber,
-                    'organization' => $contact->organization,
-                    'email'        => $contact->email,
-                    'url'          => $contact->url,
-                ],
-            ],
+            'contactMessage' => [$contactMessage],
         ];
 
         return $this->post('message/sendContact/' . $this->instance, $data);
@@ -352,7 +352,7 @@ class SendService
         $handle = fopen($file, 'rb');
 
         if ($handle === false) {
-            throw new RuntimeException('Falha ao abrir o arquivo.');
+            throw new \RuntimeException('Falha ao abrir o arquivo.');
         }
 
         $base64File = base64_encode(fread($handle, filesize($file)));
@@ -360,7 +360,7 @@ class SendService
         fclose($handle);
 
         if (!$base64File) {
-            throw new RuntimeException('Falha ao codificar o arquivo em Base64.');
+            throw new \RuntimeException('Falha ao codificar o arquivo em Base64.');
         }
 
         $filePrepared = new stdClass();


### PR DESCRIPTION
This PR introduces a new method, sendContact, which allows users to send contacts to a specified number.

It also introduces a new "**Models**" concept, enabling a more fluent usage for the `ContactMessage` class. Below is an example of how to use it:

```php
$contactMessage = new ContactMessage($phone, $phoneNonStyled, $fullName);

$evo->sendContact($contactMessage, $options);
```