### PR TITLE
[FEAT] Add necessary types to up PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": "^8.1",
         "ext-curl": "*",
-        "guzzlehttp/guzzle": "^7.0"
+        "guzzlehttp/guzzle": "^7.0",
+        "ext-fileinfo": "*"
     },
     "license": "MIT",
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
 parameters:
-	level: 4
+	level: 9
 	paths:
 		- src

--- a/src/Services/Enums/PresenceTypeEnum.php
+++ b/src/Services/Enums/PresenceTypeEnum.php
@@ -6,6 +6,9 @@ enum PresenceTypeEnum: string
 {
     case COMPOSING = 'composing';
 
+    /**
+     * @return array<string>
+     */
     public static function toArray(): array
     {
         return [

--- a/src/Services/Enums/ValidEvents.php
+++ b/src/Services/Enums/ValidEvents.php
@@ -26,6 +26,9 @@ enum ValidEvents: string
     case CALL                      = 'CALL';
     case NEW_JWT_TOKEN             = 'NEW_JWT_TOKEN';
 
+    /**
+     * @return array<string>
+     */
     public static function toArray(): array
     {
         return [

--- a/src/Services/InstanceService.php
+++ b/src/Services/InstanceService.php
@@ -50,6 +50,7 @@ class InstanceService implements Interfaces\InstanceServiceInterface
             throw new \Exception('Instance name is required.');
         }
 
+        /** @var array<string, array<string, mixed>> $instance */
         $instance = $this->post('instance/create', [
             'instanceName' => $this->name,
             'qrcode'       => true,
@@ -57,7 +58,10 @@ class InstanceService implements Interfaces\InstanceServiceInterface
         ]);
 
         if (array_key_exists('error', $instance)) {
-            throw new \Exception($instance['message']);
+            /** @var string $error */
+            $error = $instance['error'];
+
+            throw new \Exception($error);
         }
 
         $this->instance = $this->formatResponseInstance($instance);
@@ -68,7 +72,7 @@ class InstanceService implements Interfaces\InstanceServiceInterface
     /**
      * get instance
      *
-     * @return array
+     * @return array<mixed, mixed>
      */
     public function getAll(): array
     {
@@ -78,7 +82,7 @@ class InstanceService implements Interfaces\InstanceServiceInterface
     /**
      * connect instance
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function connect(): array
     {
@@ -128,7 +132,7 @@ class InstanceService implements Interfaces\InstanceServiceInterface
     /**
      * get connection state
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getState(): array
     {
@@ -136,6 +140,7 @@ class InstanceService implements Interfaces\InstanceServiceInterface
             throw new \Exception('Instance name is required.');
         }
 
+        /** @var array<string, array<string, mixed>> $state */
         $state = $this->get('instance/connectionState/' . $this->name);
 
         return [
@@ -146,8 +151,8 @@ class InstanceService implements Interfaces\InstanceServiceInterface
     /**
      * format response instance
      *
-     * @param array $instance
-     * @return array
+     * @param array<string, array<string, mixed>> $instance
+     * @return array<string, mixed>
      */
     private function formatResponseInstance(array $instance): array
     {

--- a/src/Services/Interfaces/EventServiceInterface.php
+++ b/src/Services/Interfaces/EventServiceInterface.php
@@ -4,7 +4,17 @@ namespace PHPEvo\Services\Interfaces;
 
 interface EventServiceInterface
 {
+    /**
+     * Set WebSocket in our instance
+     *
+     * @param bool $enable
+     * @param array<string> $events Events to be sent to the Webhook
+     * @return array<string, mixed>
+     */
     public function set(bool $enable = true, array $events = []): array;
 
+    /**
+     * @return array<string, mixed>
+     */
     public function find(): array;
 }

--- a/src/Services/Models/PreparedFile.php
+++ b/src/Services/Models/PreparedFile.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPEvo\Services\Models;
+
+class PreparedFile
+{
+    public function __construct(
+        public string $fileName,
+        public string $content,
+        public string $mimeType
+    ) {
+    }
+}

--- a/src/Services/RabbitService.php
+++ b/src/Services/RabbitService.php
@@ -28,7 +28,7 @@ class RabbitService implements EventServiceInterface
      * @param bool $enable
      * @param array<string> $events Events to be sent to the Webhook
      * @throws \InvalidArgumentException If an invalid event is provided
-     * @return array
+     * @return array<string, mixed>
      */
     public function set(bool $enable = true, array $events = []): array
     {
@@ -47,7 +47,7 @@ class RabbitService implements EventServiceInterface
     /**
      * Find Rabbit in our instance
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function find(): array
     {

--- a/src/Services/SQSService.php
+++ b/src/Services/SQSService.php
@@ -33,7 +33,7 @@ class SQSService implements EventServiceInterface
      * @param bool $enable
      * @param array<string> $events Events to be sent to the Webhook
      * @throws \InvalidArgumentException If an invalid event is provided
-     * @return array
+     * @return array<string, mixed>
      */
     public function set(bool $enable = true, array $events = []): array
     {
@@ -52,7 +52,7 @@ class SQSService implements EventServiceInterface
     /**
      * Find SQS in our instance
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function find(): array
     {

--- a/src/Services/Traits/HasHttpRequests.php
+++ b/src/Services/Traits/HasHttpRequests.php
@@ -13,7 +13,7 @@ trait HasHttpRequests
      * send GET request
      *
      * @param string $url
-     * @param array<string> $options
+     * @param array<mixed, mixed> $options
      * @return array<string, mixed>
      */
     protected function get(string $url, array $options = []): array
@@ -21,6 +21,7 @@ trait HasHttpRequests
         try {
             $response = $this->client->get($url, $options);
 
+            /** @var array<string, mixed> */
             return json_decode($response->getBody()->getContents(), true);
         } catch (\Exception $e) {
             return [
@@ -34,7 +35,7 @@ trait HasHttpRequests
      * send POST request
      *
      * @param string $url
-     * @param array<string> $options
+     * @param array<mixed, mixed> $options
      * @return array<string|mixed>
      */
     protected function post(string $url, array $options = []): array
@@ -45,6 +46,7 @@ trait HasHttpRequests
             ]);
 
             if ($response->getStatusCode() == 201) {
+                /** @var array<string, mixed> */
                 return json_decode($response->getBody()->getContents(), true);
             }
 
@@ -73,8 +75,8 @@ trait HasHttpRequests
      * send DELETE request
      *
      * @param string $url
-     * @param array $options
-     * @return array
+     * @param array<mixed, mixed> $options
+     * @return array<string,mixed>
      */
     protected function delete(string $url, array $options = []): array
     {

--- a/src/Services/WebSocketService.php
+++ b/src/Services/WebSocketService.php
@@ -33,7 +33,7 @@ class WebSocketService implements EventServiceInterface
      * @param bool $enable
      * @param array<string> $events Events to be sent to the Webhook
      * @throws \InvalidArgumentException If an invalid event is provided
-     * @return array
+     * @return array<string, mixed>
      */
     public function set(bool $enable = true, array $events = []): array
     {
@@ -52,7 +52,7 @@ class WebSocketService implements EventServiceInterface
     /**
      * Find WebSocket in our instance
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function find(): array
     {


### PR DESCRIPTION
I've added the iterable types required by PHPStan, created a model to represent the prepared file for the message, and improved its logic. Now, `is_readable` is used to ensure no errors occur when opening the file, and `file_get_contents` is used to achieve the same result more efficiently.

Could you also test it locally to confirm everything is working as expected?